### PR TITLE
Removal of snekfetch and usage of other hastebin-like websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,26 @@ https://www.npmjs.com/package/hastebin-gen
 ## Installation
 ```npm i -S hastebin-gen```
 
-## Example
-```
+## Examples
+Using `hastebin-gen` with the native site:
+```js
 const hastebin = require('hastebin-gen');
 hastebin("code", "js").then(r => {
     console.log(r); //https://hastebin.com/someurl.js
 }).catch(console.error);
 ```
 
+Using `hastebin-gen` with another [haste-server](https://github.com/seejohnrun/haste-server) site:
+```js
+const hastebin = require('hastebin-gen');
+hastebin("code", "js", "https://paste.discord.land/documents")
+.then(r => {
+        console.log(r) //https://paste.discord.land/someurl.js
+    }
+).catch(console.error);
+
+```
+
+
 ## Devs
-Jacz 
+[MrJacz](https://github.com/MrJacz) & [Fyko](https://github.com/Fyk0)

--- a/hastebingen.js
+++ b/hastebingen.js
@@ -1,11 +1,12 @@
-const snekfetch = require("snekfetch");
+const { promisified: p } = require('phin');
 
-module.exports = (function (input, extension) {
-    return new Promise(function (res, rej) {
-        if (!input) rej("Input argument is required.");
-        snekfetch.post("https://hastebin.com/documents").send(input).then(body => {
-            res("https://hastebin.com/" + body.body.key + ((extension) ? "." + extension : ""));
-        }).catch(e => rej(e));
-    })
-});
-// Thanks to gus for making Snekfetch a thing kthxs and PassTheMayo for recreating this ^
+module.exports = async function(code, lang = '', site = 'https://hastebin.com/documents'){
+    try{
+        const res = await p({url: site, method: 'POST', data: code})
+        const { key } = JSON.parse(res.body);
+        return `${site}/${key}${lang && `.${lang}`}`
+    }catch(err){
+        throw err;
+    }
+}
+// props to Nomsy for the model :p

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "homepage": "https://github.com/MrJacz/hastebin-gen#readme",
   "dependencies": {
-    "snekfetch": "^3.2.4"
+    "phin": "^3.3.0"
   }
 }


### PR DESCRIPTION
This PR removes the usage of [snekfetch](https://github.com/devsnek/snekfetch), which is now depreciated. This PR also allows users to post to other [hastebin-server](https://github.com/seejohnrun/haste-server)-like websites.