### PR TITLE
Fix repo link and add info for custom url

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ hastebin("code").then(r => {
 
 ## Example with a [haste-server](https://github.com/seejohnrun/haste-server) site
 ```js
-const hastebin = require('hastebin');
+const hastebin = require('hastebin-gen');
 
 hastebin("code", { url: "https://paste.example.com" }).then(r => {
     console.log(r); // https://paste.example.com/someurl.js

--- a/README.md
+++ b/README.md
@@ -19,12 +19,21 @@ https://www.npmjs.com/package/hastebin-gen
 
 **Yarn:** ```yarn add hastebin-gen```
 
-## Example
-```
+## Example with Native Site (hastebin.com)
+```js
 const hastebin = require("hastebin-gen");
 
 hastebin("code").then(r => {
-    console.log(r); //https://hastebin.com/someurl.js
+    console.log(r); // https://hastebin.com/someurl.js
+}).catch(console.error);
+```
+
+## Example with a [haste-server](https://github.com/seejohnrun/haste-server) site
+```js
+const hastebin = require('hastebin');
+
+hastebin("code", { url: "https://paste.example.com" }).then(r => {
+    console.log(r); // https://paste.example.com/someurl.js
 }).catch(console.error);
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hastebin-gen",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A simple hastebin client for uploading things to hastebin.com",
   "main": "src/index.js",
   "types": "typings/index.d.ts",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/MrJacz/discord.js-lavalink.git"
+    "url": "git+https://github.com/MrJacz/hastebin-gen.git"
   },
   "author": "Jacz <jacz@jaczaus.me>",
   "license": "MIT",


### PR DESCRIPTION
This PR addresses:
- Updated `git.repo` in `package.json` that links to this repository
- Updated `README.md` to include an example of how to use a different URL for the haste server (ex. `https://paste.example.com`) as well as code-block highlighting